### PR TITLE
fix #APPINT-129

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The properties file can contain the following values
 # => environment
 # The environment to connect to. If set to 'production' then all Single Sign-On (SSO) and API requests will be made to maestrano.com. If set to 'test' then requests will be made to api-sandbox.maestrano.io. 
 # The api-sandbox allows you to easily test integration scenarios.
-app.environment=test
+environment=test
 
 # => host
 # This is your application host (e.g: my-app.com) which is ultimately used to redirect users to the right SAML url during SSO handshake.
@@ -108,6 +108,9 @@ app.host=http\://localhost:8080
 api.id=prod_or_sandbox_app_id
 api.key=prod_or_sandbox_api_key
 
+# Api Host
+# The platform host
+api.host=https://maestrano.com
 
 # ===> SSO Configuration
 #
@@ -145,6 +148,11 @@ sso.consumePath=/maestrano/auth/saml/consume
 # For multi-tenant integration, the certificates may change per environment.
 sso.x509Fingerprint=2f:57:71:e4:40:19:57:37:a6:2c:f0:c5:82:52:2f:2e:41:b7:9d:7e
 sso.x509Certificate=-----BEGIN CERTIFICATE-----\nCERTIFICATE CONTENT==\n-----END CERTIFICATE-----
+
+# => Connec Host
+# The Connec! endpoint used to fetch data from
+connec.host=https://api-connec.maestrano.com
+connec.base=/api/v2
 
 # => creationMode
 # !IMPORTANT
@@ -230,7 +238,7 @@ You can configure maestrano with the Properties class using the same configurati
 
 ```java
     Properties props = new Properties();
-    props.setProperty("app.environment", "production");
+    props.setProperty("environment", "production");
     Maestrano.configure(props);
 ```
 

--- a/src/main/java/com/maestrano/ApiService.java
+++ b/src/main/java/com/maestrano/ApiService.java
@@ -10,28 +10,29 @@ import com.maestrano.helpers.MnoPropertiesHelper;
  * Maestrano API Service, related to all Maestrano API
  */
 public class ApiService {
-	private static final String TEST_ACCOUNT_HOST = "http://api-sandbox.maestrano.io";
+	private static final String PROD_API_HOST = "https://maestrano.com";
+	private static final String TEST_API_HOST = "http://api-sandbox.maestrano.io";
 
 	private static final String PROD_CONNEC_HOST = "https://api-connec.maestrano.com";
-	private static final String PROD_ACCOUNT_HOST = "https://maestrano.com";
+
 
 	private final String id;
 	private final String key;
 	private final boolean verifySslCerts;
 	private final String accountBase;
-	private final String accountHost;
+	private final String host;
 	private final String connecHost;
 	private final String connecBase;
 
 	// package private Constructor
 	ApiService(AppService appService, Properties props) {
-		this.id = MnoPropertiesHelper.getProperty("api.id", props);
-		this.key = MnoPropertiesHelper.getProperty("api.key", props);
-		this.accountBase = MnoPropertiesHelper.getProperty("api.accountBase", props);
-		this.accountHost = getAccountHost(appService, props);
+		this.id = MnoPropertiesHelper.getPropertyOrDefault(props, "api.id");
+		this.key = MnoPropertiesHelper.getPropertyOrDefault(props, "api.key");
+		this.accountBase = MnoPropertiesHelper.getPropertyOrDefault(props, "api.accountBase");
+		this.host = getApiHost(appService, props);
 		this.connecBase = getConnecBase(appService, props);
 		this.connecHost = getConnecHost(appService, props);
-		this.verifySslCerts = MnoPropertiesHelper.getBooleanProperty("api.verifySslCerts", props);
+		this.verifySslCerts = MnoPropertiesHelper.getBooleanProperty(props, "api.verifySslCerts");
 	}
 
 	/**
@@ -57,19 +58,19 @@ public class ApiService {
 	 * 
 	 * @return String host
 	 */
-	public String getAccountHost() {
-		return accountHost;
+	public String getHost() {
+		return host;
 	}
 
-	private static String getAccountHost(AppService appService, Properties props) {
-		String accountHost = props.getProperty("api.accountHost");
-		if (!MnoPropertiesHelper.isNullOrEmpty(accountHost)) {
-			return accountHost;
+	private static String getApiHost(AppService appService, Properties props) {
+		String apiHost = MnoPropertiesHelper.getProperty(props, "api.host", "api.accountHost");
+		if (!MnoPropertiesHelper.isNullOrEmpty(apiHost)) {
+			return apiHost;
 		} else {
 			if (appService.isProduction()) {
-				return PROD_ACCOUNT_HOST;
+				return PROD_API_HOST;
 			} else {
-				return TEST_ACCOUNT_HOST;
+				return TEST_API_HOST;
 			}
 		}
 	}
@@ -93,14 +94,14 @@ public class ApiService {
 	}
 
 	private static String getConnecHost(AppService appService, Properties props) {
-		String connecHost = props.getProperty("api.connecHost");
+		String connecHost = MnoPropertiesHelper.getProperty(props, "connec.host", "api.connecHost");
 		if (!MnoPropertiesHelper.isNullOrEmpty(connecHost)) {
 			return connecHost;
 		} else {
 			if (appService.isProduction()) {
 				return PROD_CONNEC_HOST;
 			} else {
-				return TEST_ACCOUNT_HOST;
+				return TEST_API_HOST;
 			}
 		}
 	}
@@ -120,7 +121,7 @@ public class ApiService {
 	 * @return String base
 	 */
 	private static String getConnecBase(AppService appService, Properties props) {
-		String connecBase = props.getProperty("api.connecBase");
+		String connecBase = MnoPropertiesHelper.getProperty(props, "connec.base", "api.connecBase");
 		if (!MnoPropertiesHelper.isNullOrEmpty(connecBase)) {
 			return connecBase;
 		} else {

--- a/src/main/java/com/maestrano/AppService.java
+++ b/src/main/java/com/maestrano/AppService.java
@@ -16,8 +16,8 @@ public class AppService {
 
 	// package private Constructor
 	AppService(Properties props) {
-		this.environment = MnoPropertiesHelper.getProperty("app.environment", props);
-		this.host = MnoPropertiesHelper.getProperty("app.host", props);
+		this.environment = MnoPropertiesHelper.getPropertyOrDefault(props, "environment", "app.environment");
+		this.host = MnoPropertiesHelper.getPropertyOrDefault(props, "app.host");
 	}
 
 	/**

--- a/src/main/java/com/maestrano/Maestrano.java
+++ b/src/main/java/com/maestrano/Maestrano.java
@@ -18,6 +18,7 @@ import javax.xml.bind.DatatypeConverter;
 import com.google.gson.Gson;
 import com.maestrano.exception.MnoConfigurationException;
 import com.maestrano.exception.MnoException;
+import com.maestrano.helpers.MnoPropertiesHelper;
 
 /**
  * <p>
@@ -59,10 +60,11 @@ public final class Maestrano {
 
 	// Private constructor
 	private Maestrano(Properties props) {
-		this.appService = new AppService(props);
-		this.apiService = new ApiService(appService, props);
-		this.ssoService = new SsoService(apiService, appService, props);
-		this.webhookService = new WebhookService(props);
+		Properties trimmedProperties = MnoPropertiesHelper.trimProperties(props);
+		this.appService = new AppService(trimmedProperties);
+		this.apiService = new ApiService(appService, trimmedProperties);
+		this.ssoService = new SsoService(apiService, appService, trimmedProperties);
+		this.webhookService = new WebhookService(trimmedProperties);
 	}
 
 	/**
@@ -71,7 +73,7 @@ public final class Maestrano {
 	 * @return String version
 	 */
 	public static String getVersion() {
-		return "1.0.0";
+		return "0.9.2-SNAPSHOT";
 	}
 
 	/**

--- a/src/main/java/com/maestrano/SsoService.java
+++ b/src/main/java/com/maestrano/SsoService.java
@@ -26,14 +26,14 @@ public class SsoService {
 	// Package Private Constructor
 	SsoService(ApiService apiService, AppService appService, Properties props) {
 		this.apiService = apiService;
-		this.enabled = MnoPropertiesHelper.getBooleanProperty("sso.enabled", props);
-		this.sloEnabled = MnoPropertiesHelper.getBooleanProperty("sso.sloEnabled", props);
-		this.creationMode = MnoPropertiesHelper.getProperty("sso.creationMode", props);
-		this.initPath = MnoPropertiesHelper.getProperty("sso.initPath", props);
-		this.consumePath = MnoPropertiesHelper.getProperty("sso.consumePath", props);
+		this.enabled = MnoPropertiesHelper.getBooleanProperty(props, "sso.enabled");
+		this.sloEnabled = MnoPropertiesHelper.getBooleanProperty(props, "sso.sloEnabled");
+		this.creationMode = MnoPropertiesHelper.getPropertyOrDefault(props, "sso.creationMode");
+		this.initPath = MnoPropertiesHelper.getPropertyOrDefault(props, "sso.initPath");
+		this.consumePath = MnoPropertiesHelper.getPropertyOrDefault(props, "sso.consumePath");
 		this.idm = getIdm(appService, props);
 		this.idp = getIdp(appService, props);
-		this.nameIdFormat = MnoPropertiesHelper.getProperty("sso.nameIdFormat", props);
+		this.nameIdFormat = MnoPropertiesHelper.getPropertyOrDefault(props, "sso.nameIdFormat");
 		this.x509Fingerprint = getX509Fingerprint(appService, props);
 		this.x509Certificate = getX509Certificate(appService, props);
 

--- a/src/main/java/com/maestrano/WebhookService.java
+++ b/src/main/java/com/maestrano/WebhookService.java
@@ -16,9 +16,9 @@ public class WebhookService {
 	// Package Private Constructor
 	WebhookService(Properties props) {
 
-		this.accountGroupsPath = MnoPropertiesHelper.getProperty("webhook.account.groupsPath", props);
-		this.accountGroupUsersPath = MnoPropertiesHelper.getProperty("webhook.account.groupUsersPath", props);
-		this.notificationspath = MnoPropertiesHelper.getProperty("webhook.connec.notificationsPath", props);
+		this.accountGroupsPath = MnoPropertiesHelper.getPropertyOrDefault(props, "webhook.account.groupsPath");
+		this.accountGroupUsersPath = MnoPropertiesHelper.getPropertyOrDefault(props, "webhook.account.groupUsersPath");
+		this.notificationspath = MnoPropertiesHelper.getPropertyOrDefault(props, "webhook.connec.notificationsPath");
 		this.connecSubscriptions = new HashMap<String, Boolean>();
 		// Map properties under "webhook.connec.subscriptions" as a Map
 		for (String key : props.stringPropertyNames()) {

--- a/src/main/java/com/maestrano/helpers/MnoPropertiesHelper.java
+++ b/src/main/java/com/maestrano/helpers/MnoPropertiesHelper.java
@@ -2,6 +2,8 @@ package com.maestrano.helpers;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Iterator;
 import java.util.Properties;
 
 public class MnoPropertiesHelper {
@@ -17,26 +19,47 @@ public class MnoPropertiesHelper {
 		} catch (IOException cantHappen) {
 			throw new RuntimeException(cantHappen);
 		}
-		return properties;
+		return trimProperties(properties);
+	}
+	/**
+	 * @return a properties where all the property valuegetPropertys are trimmed
+	 */
+	public static Properties trimProperties(Properties input) {
+		Properties output = new Properties();
+		for (String key : input.stringPropertyNames()) {
+			output.put(key, input.getProperty(key).trim());
+		}
+		return output;
 	}
 
-	public static String getProperty(String key, Properties properties) {
+	/**
+	 * @return the property with the specified key, if null tries the legacy keys
+	 */
+	public static String getProperty(Properties properties, String key, String... legacyKeys) {
 		String property = properties.getProperty(key);
+		Iterator<String> iterator = Arrays.asList(legacyKeys).iterator();
+		while (isNullOrEmpty(property) && iterator.hasNext()) {
+			property = properties.getProperty(iterator.next());
+		}
+		return property;
+	}
+
+	/**
+	 * @return the property with the specified key, if null tries the legacy keys, if still null, take the DEFAULT_PROPERTIES value
+	 */
+	public static String getPropertyOrDefault(Properties properties, String key, String... legacyKeys) {
+		String property = getProperty(properties, key, legacyKeys);
 		if (isNullOrEmpty(property)) {
 			property = DEFAULT_PROPERTIES.getProperty(key);
 		}
-		if (property == null) {
-			return null;
-		} else {
-			return property.trim();
-		}
+		return property;
 	}
 
 	public static boolean isNullOrEmpty(String property) {
-		return property == null || property.trim().length() == 0;
+		return property == null || property.length() == 0;
 	}
 
-	public static boolean getBooleanProperty(String key, Properties properties) {
-		return "true".equalsIgnoreCase(getProperty(key, properties));
+	public static boolean getBooleanProperty(Properties properties, String key, String... legacyKeys) {
+		return "true".equalsIgnoreCase(getPropertyOrDefault(properties, key, legacyKeys));
 	}
 }

--- a/src/main/java/com/maestrano/net/MnoAccountClient.java
+++ b/src/main/java/com/maestrano/net/MnoAccountClient.java
@@ -82,7 +82,7 @@ public class MnoAccountClient<T> {
 	 * @return collection url
 	 */
 	public String getCollectionUrl() {
-		return maestraeno.apiService().getAccountHost() + getCollectionEndpoint();
+		return maestraeno.apiService().getHost() + getCollectionEndpoint();
 	}
 
 	/**
@@ -108,7 +108,7 @@ public class MnoAccountClient<T> {
 	 * @return instance url
 	 */
 	public String getInstanceUrl(String id) {
-		return maestraeno.apiService().getAccountHost() + getInstanceEndpoint(id);
+		return maestraeno.apiService().getHost() + getInstanceEndpoint(id);
 	}
 
 	/**

--- a/src/main/resources/com/maestrano/default.config.properties
+++ b/src/main/resources/com/maestrano/default.config.properties
@@ -1,7 +1,7 @@
-app.environment=test
+environment=test
 app.host=http://localhost:8080
 api.verifySslCerts=false
-api.accountBase=/api/v1/account 
+api.accountBase=/api/v1/account
 
 sso.enabled=true
 sso.sloEnabled=true
@@ -12,6 +12,6 @@ sso.consumePath=/maestrano/auth/saml/consume
 sso.creationMode=virtual
 sso.nameIdFormat=urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
 
-webhook.account.groupsPath = /maestrano/account/groups/:id
-webhook.account.groupUsersPath = /maestrano/account/groups/:group_id/users/:id
-webhook.connec.notificationsPath = /maestrano/connec/notifications
+webhook.account.groupsPath=/maestrano/account/groups/:id
+webhook.account.groupUsersPath=/maestrano/account/groups/:group_id/users/:id
+webhook.connec.notificationsPath=/maestrano/connec/notifications

--- a/src/test/java/com/maestrano/ApiServiceTest.java
+++ b/src/test/java/com/maestrano/ApiServiceTest.java
@@ -16,7 +16,7 @@ public class ApiServiceTest {
 
 	@Before
 	public void beforeEach() {
-		props.setProperty("app.environment", "production");
+		props.setProperty("environment", "production");
 		props.setProperty("api.id", "someid");
 		props.setProperty("api.key", "somekey");
 		Maestrano maestrano = Maestrano.reloadConfiguration(props);
@@ -53,8 +53,8 @@ public class ApiServiceTest {
 	}
 	
 	@Test
-	public void getAccountHost_itReturnsTheRightProductionValue() {
-		assertEquals("https://maestrano.com", subject.getAccountHost());
+	public void getHost_itReturnsTheRightProductionValue() {
+		assertEquals("https://maestrano.com", subject.getHost());
 	}
 	
 	@Test
@@ -73,12 +73,12 @@ public class ApiServiceTest {
 	}
 	
 	@Test
-	public void getAccountHost_itReturnsTheRightValue() throws MnoException {
+	public void getHost_itReturnsTheRightValue() throws MnoException {
 		String host = "https://mysuperapp.com";
-		props.setProperty("api.accountHost", host);
+		props.setProperty("api.host", host);
 		Maestrano maestrano = Maestrano.reloadConfiguration(props);
 		ApiService apiService = maestrano.apiService();
-		assertEquals(host, apiService.getAccountHost());
+		assertEquals(host, apiService.getHost());
 	}
 	
 	@Test

--- a/src/test/java/com/maestrano/AppServiceTest.java
+++ b/src/test/java/com/maestrano/AppServiceTest.java
@@ -14,7 +14,7 @@ public class AppServiceTest {
 
 	@Before
 	public void beforeEach() {
-		props.setProperty("app.environment", "production");
+		props.setProperty("environment", "production");
 		props.setProperty("app.host", "https://mysuperapp.com");
 		
 		Maestrano maestrano = Maestrano.reloadConfiguration(props);

--- a/src/test/java/com/maestrano/MaestranoTest.java
+++ b/src/test/java/com/maestrano/MaestranoTest.java
@@ -25,13 +25,13 @@ public class MaestranoTest {
 
 	@Before
 	public void beforeEach() {
-		defaultProps.setProperty("app.environment", "production");
+		defaultProps.setProperty("environment", "production");
 		defaultProps.setProperty("app.host", "https://mysuperapp.com");
 		defaultProps.setProperty("api.id", "someid");
 		defaultProps.setProperty("api.key", "somekey");
 		maestrano = Maestrano.reloadConfiguration(defaultProps);
 
-		otherProps.setProperty("app.environment", "production");
+		otherProps.setProperty("environment", "production");
 		otherProps.setProperty("app.host", "https://myotherapp.com");
 		otherProps.setProperty("api.id", "otherid");
 		otherProps.setProperty("api.key", "otherkey");

--- a/src/test/java/com/maestrano/SsoServiceTest.java
+++ b/src/test/java/com/maestrano/SsoServiceTest.java
@@ -17,7 +17,7 @@ public class SsoServiceTest {
 	
 	@Before
 	public void beforeEach() {
-		props.setProperty("app.environment", "production");
+		props.setProperty("environment", "production");
 		props.setProperty("api.id", "someid");
 		props.setProperty("api.key", "somekey");
 		maestrano = Maestrano.reloadConfiguration(props);

--- a/src/test/java/com/maestrano/WebhookServiceTest.java
+++ b/src/test/java/com/maestrano/WebhookServiceTest.java
@@ -13,7 +13,7 @@ public class WebhookServiceTest {
 	private WebhookService subject;
 	@Before
 	public void beforeEach() {
-		props.setProperty("app.environment", "production");
+		props.setProperty("environment", "production");
 		reloadConfiguration();
 	}
 

--- a/src/test/java/com/maestrano/account/MnoBillIntegrationTest.java
+++ b/src/test/java/com/maestrano/account/MnoBillIntegrationTest.java
@@ -22,7 +22,7 @@ public class MnoBillIntegrationTest {
 	
 	@Before
 	public void beforeEach() {
-		props.setProperty("app.environment", "test");
+		props.setProperty("environment", "test");
 		props.setProperty("api.id", "app-1");
 		props.setProperty("api.key", "gfcmbu8269wyi0hjazk4t7o1sndpvrqxl53e1");
 		Maestrano.reloadConfiguration(props);

--- a/src/test/java/com/maestrano/account/MnoGroupIntegrationTest.java
+++ b/src/test/java/com/maestrano/account/MnoGroupIntegrationTest.java
@@ -21,7 +21,7 @@ public class MnoGroupIntegrationTest {
 
 	@Before
 	public void beforeEach() {
-		props.setProperty("app.environment", "test");
+		props.setProperty("environment", "test");
 		props.setProperty("api.id", "app-1");
 		props.setProperty("api.key", "gfcmbu8269wyi0hjazk4t7o1sndpvrqxl53e1");
 		Maestrano.reloadConfiguration(props);

--- a/src/test/java/com/maestrano/account/MnoRecurringBillIntegrationTest.java
+++ b/src/test/java/com/maestrano/account/MnoRecurringBillIntegrationTest.java
@@ -22,7 +22,7 @@ public class MnoRecurringBillIntegrationTest {
 	@Before
 	public void beforeEach() {
 		Properties props = new Properties();
-		props.setProperty("app.environment", "test");
+		props.setProperty("environment", "test");
 		props.setProperty("api.id", "app-1");
 		props.setProperty("api.key", "gfcmbu8269wyi0hjazk4t7o1sndpvrqxl53e1");
 		Maestrano.reloadConfiguration(props);

--- a/src/test/java/com/maestrano/account/MnoUserIntegrationTest.java
+++ b/src/test/java/com/maestrano/account/MnoUserIntegrationTest.java
@@ -19,7 +19,7 @@ public class MnoUserIntegrationTest {
 	@Before
 	public void beforeEach() {
 		Properties props = new Properties();
-		props.setProperty("app.environment", "test");
+		props.setProperty("environment", "test");
 		props.setProperty("api.id", "app-1");
 		props.setProperty("api.key", "gfcmbu8269wyi0hjazk4t7o1sndpvrqxl53e1");
 		Maestrano.reloadConfiguration(props);

--- a/src/test/java/com/maestrano/helpers/MnoPropertiesHelperTest.java
+++ b/src/test/java/com/maestrano/helpers/MnoPropertiesHelperTest.java
@@ -1,0 +1,42 @@
+package com.maestrano.helpers;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+public class MnoPropertiesHelperTest {
+	@Test
+	public void getPropertyOrDefault_itReturnsTheRightGivenProperty() {
+		Properties properties = new Properties();
+		properties.setProperty("environment", "overloaded");
+		properties.setProperty("api.id", "app-1");
+		properties.setProperty("api.key", "gfcmbu8269wyi0hjazk4t7o1sndpvrqxl53e1");
+
+		Assert.assertEquals("overloaded", MnoPropertiesHelper.getPropertyOrDefault(properties, "environment"));
+		Assert.assertEquals("app-1", MnoPropertiesHelper.getPropertyOrDefault(properties, "api.id"));
+		Assert.assertEquals("gfcmbu8269wyi0hjazk4t7o1sndpvrqxl53e1", MnoPropertiesHelper.getPropertyOrDefault(properties, "api.key"));
+
+	}
+
+	@Test
+	public void getPropertyOrDefault_itReturnsTheRightDefaultProperty() {
+		Properties properties = new Properties();
+
+		Assert.assertEquals("test", MnoPropertiesHelper.getPropertyOrDefault(properties, "environment"));
+		Assert.assertEquals("/maestrano/account/groups/:id", MnoPropertiesHelper.getPropertyOrDefault(properties, "webhook.account.groupsPath"));
+		Assert.assertEquals("/maestrano/account/groups/:group_id/users/:id", MnoPropertiesHelper.getPropertyOrDefault(properties, "webhook.account.groupUsersPath"));
+		Assert.assertEquals("/maestrano/connec/notifications", MnoPropertiesHelper.getPropertyOrDefault(properties, "webhook.connec.notificationsPath"));
+
+	}
+
+	@Test
+	public void getPropertyOrDefault_itReturnsTheRightLegacyProperty() {
+		Properties properties = new Properties();
+		properties.setProperty("legacyPropertyKey", "value");
+
+		Assert.assertEquals("value", MnoPropertiesHelper.getPropertyOrDefault(properties, "propertyKey", "legacyPropertyKey"));
+	}
+
+}

--- a/src/test/java/com/maestrano/net/ConnecClientIntegrationTest.java
+++ b/src/test/java/com/maestrano/net/ConnecClientIntegrationTest.java
@@ -18,7 +18,7 @@ public class ConnecClientIntegrationTest {
     
     @Before
     public void beforeEach() {
-        props.setProperty("app.environment", "test");
+        props.setProperty("environment", "test");
         props.setProperty("api.id", "app-1");
         props.setProperty("api.key", "gfcmbu8269wyi0hjazk4t7o1sndpvrqxl53e1");
         Maestrano.reloadConfiguration(props);

--- a/src/test/java/com/maestrano/net/ConnecClientTest.java
+++ b/src/test/java/com/maestrano/net/ConnecClientTest.java
@@ -39,18 +39,18 @@ public class ConnecClientTest {
 	
 	@Before
 	public void beforeEach()  {
-	    defaultProps.setProperty("app.environment", "production");
+	    defaultProps.setProperty("environment", "production");
         defaultProps.setProperty("app.host", "https://mysuperapp.com");
         defaultProps.setProperty("api.id", "someid");
         defaultProps.setProperty("api.key", "somekey");
-        defaultProps.setProperty("api.connecHost", "https://api-connec.maestrano.com");
+        defaultProps.setProperty("connec.host", "https://api-connec.maestrano.com");
         Maestrano.reloadConfiguration(defaultProps);
         
-        otherProps.setProperty("app.environment", "production");
+        otherProps.setProperty("environment", "production");
         otherProps.setProperty("app.host", "https://myotherapp.com");
         otherProps.setProperty("api.id", "otherid");
         otherProps.setProperty("api.key", "otherkey");
-        otherProps.setProperty("api.connecHost", "https://api-connec.other.com");
+        otherProps.setProperty("connec.host", "https://api-connec.other.com");
         Maestrano.reloadConfiguration("other", otherProps);
         
         this.connecClient = ConnecClient.defaultClient();

--- a/src/test/java/com/maestrano/net/MnoAccountClientTest.java
+++ b/src/test/java/com/maestrano/net/MnoAccountClientTest.java
@@ -26,7 +26,7 @@ public class MnoAccountClientTest {
 
 	@Before
 	public void beforeEach() throws Exception {
-		props.setProperty("app.environment", "production");
+		props.setProperty("environment", "production");
 		props.setProperty("app.host", "https://mysuperapp.com");
 		props.setProperty("api.id", "someid");
 		props.setProperty("api.key", "somekey");

--- a/src/test/java/com/maestrano/saml/AuthRequestTest.java
+++ b/src/test/java/com/maestrano/saml/AuthRequestTest.java
@@ -26,7 +26,7 @@ public class AuthRequestTest {
 	private Maestrano maestrano;
 	@Before
 	public void beforeEach() {
-		props.setProperty("app.environment", "production");
+		props.setProperty("environment", "production");
 		props.setProperty("app.host", "https://mysuperapp.com");
 		props.setProperty("api.id", "someid");
 		props.setProperty("api.key", "somekey");

--- a/src/test/java/com/maestrano/saml/ResponseTest.java
+++ b/src/test/java/com/maestrano/saml/ResponseTest.java
@@ -21,7 +21,7 @@ public class ResponseTest {
 
 	@Before
 	public void beforeEach() throws CertificateException, MnoException {
-		props.setProperty("app.environment", "production");
+		props.setProperty("environment", "production");
 		props.setProperty("app.host", "https://mysuperapp.com");
 		props.setProperty("api.id", "someid");
 		props.setProperty("api.key", "somekey");

--- a/src/test/java/com/maestrano/sso/MnoGroupTest.java
+++ b/src/test/java/com/maestrano/sso/MnoGroupTest.java
@@ -22,7 +22,7 @@ public class MnoGroupTest {
 
 	@Before
 	public void beforeEach() throws Exception {
-		props.setProperty("app.environment", "production");
+		props.setProperty("environment", "production");
 		props.setProperty("app.host", "https://mysuperapp.com");
 		props.setProperty("api.id", "someid");
 		props.setProperty("api.key", "somekey");

--- a/src/test/java/com/maestrano/sso/MnoSessionTest.java
+++ b/src/test/java/com/maestrano/sso/MnoSessionTest.java
@@ -30,7 +30,7 @@ public class MnoSessionTest {
 
 	@Before
 	public void beforeEach() throws Exception {
-		props.setProperty("app.environment", "production");
+		props.setProperty("environment", "production");
 		props.setProperty("app.host", "https://mysuperapp.com");
 		props.setProperty("api.id", "someid");
 		props.setProperty("api.key", "somekey");
@@ -38,7 +38,7 @@ public class MnoSessionTest {
 		Maestrano.reloadConfiguration(props);
 
 		Properties otherProps = new Properties();
-		otherProps.setProperty("app.environment", "theotherproduction");
+		otherProps.setProperty("environment", "theotherproduction");
 		otherProps.setProperty("app.host", "https://theothersuperapp.com");
 		otherProps.setProperty("api.id", "anotherId");
 		otherProps.setProperty("api.key", "anotherKey");

--- a/src/test/java/com/maestrano/sso/MnoUserTest.java
+++ b/src/test/java/com/maestrano/sso/MnoUserTest.java
@@ -22,7 +22,7 @@ public class MnoUserTest {
 
 	@Before
 	public void beforeEach() throws Exception {
-		props.setProperty("app.environment", "production");
+		props.setProperty("environment", "production");
 		props.setProperty("app.host", "https://mysuperapp.com");
 		props.setProperty("api.id", "someid");
 		props.setProperty("api.key", "somekey");


### PR DESCRIPTION
Java SDK update of metadata access and doc
replaced property keys:
- app.environment to environment
- api.accountHost to api.host
- api.connectHost to connec.host
  always trim properties
  renamed MnoPropertiesHelper.getPropertyOrDefault to getProperty
