### PR TITLE
Match dev platform properties between the different SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The properties file may look like this:
 # This is the host and base path that should be used by your environment to retrieve its marketplaces configuration.
 # The api-sandbox allows you to easily test integration scenarios.
 dev-platform.host=https://dev-platform.maestrano.com
-dev-platform.v1Path=/api/config/v1/marketplaces
+dev-platform.api_path=/api/config/v1
 # => Environment credentials
 # These are your environment credentials, you can get them by connecting on the developer platform, then go on your app, they will be display under the technical view on each environment.
 environment.name=<your environment nid>
@@ -95,11 +95,11 @@ environment.apiSecret=<your environment secret>
 
 You can also use environment variables as follow to configure your app environment:
 ```
-export DEVPL_HOST=<developer platform host>
-export DEVPL_V1_PATH=<developer platform host>
-export ENVIRONMENT_NAME=<your environment nid>
-export ENVIRONMENT_KEY=<your environment key>
-export ENVIRONMENT_SECRET=<your environment secret>
+export MNO_DEVPL_HOST=<developer platform host>
+export MNO_DEVPL_API_PATH=<developer platform host>
+export MNO_DEVPL_ENV_NAME=<your environment nid>
+export MNO_DEVPL_ENV_KEY=<your environment key>
+export MNO_DEVPL_ENV_SECRET=<your environment secret>
 ```
 and directly call
 ```java
@@ -108,6 +108,8 @@ Maestrano:autoConfigure();
 You may also call autoConfigure using a Properties instance.
 ```java
 Properties properties = new Properties();
+properties.setProperty("dev-platform.host", "https://dev-platform.maestrano.com");
+properties.setProperty("dev-platform.api_path", "/api/config/v1");
 properties.setProperty("environment.name", "<your environment nid>");
 properties.setProperty("environment.apiKey", "<your environment key>");
 properties.setProperty("environment.apiSecret", "<your environment secret>");
@@ -132,11 +134,16 @@ More information about multi-tenant integration can be found on [Our Multi-Tenan
 ```java
     // Load configuration
     Maestrano config1 = Maestrano.configure("config1", "config1.properties");
-    Maestrano config" = Maestrano.configure("config2", "config2.properties");
+    Maestrano config = Maestrano.configure("config2", "config2.properties");
     
     // Access configuration with presets
     config1.toMetadata();
     config2.toMetadata();
+    
+    //...
+    
+    // Access configuration with presets elsewhere
+    Maestrano.get("config1").toMetadata();
 ```
 
 The properties file can contain the following values

--- a/src/main/java/com/maestrano/DevPlatformService.java
+++ b/src/main/java/com/maestrano/DevPlatformService.java
@@ -10,17 +10,17 @@ import com.maestrano.helpers.MnoPropertiesHelper;
  */
 public class DevPlatformService {
 	private final String host;
-	private final String v1Path;
+	private final String apiPath;
 	private final String environmentName;
 	private final String apiKey;
 	private final String apiSecret;
 
 	public DevPlatformService(Properties properties) throws MnoConfigurationException {
-		host = MnoPropertiesHelper.getPropertyOrEnvironment(properties, "dev-platform.host", "DEVPL_HOST", "https://dev-platform.maestrano.com");
-		v1Path = MnoPropertiesHelper.getPropertyOrEnvironment(properties, "dev-platform.v1Path", "DEVPL_V1_PATH", "/api/config/v1/marketplaces");
-		environmentName = MnoPropertiesHelper.getPropertyOrEnvironment(properties, "environment.name", "ENVIRONMENT_NAME");
-		apiKey = MnoPropertiesHelper.getPropertyOrEnvironment(properties, "environment.apiKey", "ENVIRONMENT_KEY");
-		apiSecret = MnoPropertiesHelper.getPropertyOrEnvironment(properties, "environment.apiSecret", "ENVIRONMENT_SECRET");
+		host = MnoPropertiesHelper.getPropertyOrEnvironment(properties, "dev-platform.host", "MNO_DEVPL_HOST", "https://dev-platform.maestrano.com");
+		apiPath = MnoPropertiesHelper.getPropertyOrEnvironment(properties, "dev-platform.apiPath", "MNO_DEVPL_API_PATH", "/api/config/v1");
+		environmentName = MnoPropertiesHelper.getPropertyOrEnvironment(properties, "environment.name", "MNO_DEVPL_ENV_NAME");
+		apiKey = MnoPropertiesHelper.getPropertyOrEnvironment(properties, "environment.apiKey", "MNO_DEVPL_ENV_KEY");
+		apiSecret = MnoPropertiesHelper.getPropertyOrEnvironment(properties, "environment.apiSecret", "MNO_DEVPL_ENV_SECRET");
 	}
 
 	/**
@@ -31,10 +31,10 @@ public class DevPlatformService {
 	}
 
 	/**
-	 * @return The path of the V1 API
+	 * @return The path of the API
 	 */
-	public String getV1Path() {
-		return v1Path;
+	public String getApiPath() {
+		return apiPath;
 	}
 
 	/**

--- a/src/main/java/com/maestrano/Maestrano.java
+++ b/src/main/java/com/maestrano/Maestrano.java
@@ -139,7 +139,7 @@ public final class Maestrano {
 		Map<String, Maestrano> configurations = new LinkedHashMap<String, Maestrano>();
 		for (MarketplaceConfiguration marketplaceConfiguration : marketplaceConfigurations) {
 			String preset = marketplaceConfiguration.getName();
-			Maestrano maestrano = configure(preset, marketplaceConfiguration.getProperties());
+			Maestrano maestrano = reloadConfiguration(preset, marketplaceConfiguration.getProperties());
 			configurations.put(preset, maestrano);
 		}
 		logger.debug("autoConfigure() found {}", configurations.keySet());
@@ -186,7 +186,7 @@ public final class Maestrano {
 	}
 
 	/**
-	 * Configure Maestrano API using a Properties o for the given preset
+	 * Configure Maestrano API using a Properties for the given preset
 	 * 
 	 * @param String
 	 *            preset

--- a/src/main/java/com/maestrano/net/DevPlatformClient.java
+++ b/src/main/java/com/maestrano/net/DevPlatformClient.java
@@ -42,7 +42,7 @@ public class DevPlatformClient {
 	public List<MarketplaceConfiguration> getMarketplaceConfigurations(MnoHttpClient client) throws MnoConfigurationException {
 		String string;
 		try {
-			string = client.get(getInstanceUrl());
+			string = client.get(getInstanceUrl() + "/marketplaces");
 		} catch (MnoException e) {
 			throw new MnoConfigurationException("Could not retrieve the list of the marketplace: " + e.getMessage(), e);
 		}
@@ -83,6 +83,6 @@ public class DevPlatformClient {
 	}
 
 	public String getInstanceUrl() {
-		return devPlatformService.getHost() + devPlatformService.getV1Path();
+		return devPlatformService.getHost() + devPlatformService.getApiPath();
 	}
 }

--- a/src/test/java/com/maestrano/DevPlatformServiceTest.java
+++ b/src/test/java/com/maestrano/DevPlatformServiceTest.java
@@ -22,7 +22,7 @@ public class DevPlatformServiceTest {
 
 		DevPlatformService subject = new DevPlatformService(properties);
 		Assert.assertEquals("https://dev-platform.maestrano.com", subject.getHost());
-		Assert.assertEquals("/api/config/v1/marketplaces", subject.getV1Path());
+		Assert.assertEquals("/api/config/v1", subject.getApiPath());
 		Assert.assertEquals("name", subject.getEnvironmentName());
 		Assert.assertEquals("apiKey", subject.getApiKey());
 		Assert.assertEquals("apiSecret", subject.getApiSecret());
@@ -32,7 +32,7 @@ public class DevPlatformServiceTest {
 	public void constructor_usingEnvironmentVariable_itReturnTheRightValues() throws MnoConfigurationException {
 		Properties properties = new Properties();
 		// This is to override the call to System.getEnv
-		final Map<String, String> environmentValues = ImmutableMap.of("ENVIRONMENT_NAME", "theHost", "ENVIRONMENT_KEY", "theKey", "ENVIRONMENT_SECRET", "theSecret");
+		final Map<String, String> environmentValues = ImmutableMap.of("MNO_DEVPL_ENV_NAME", "theHost", "MNO_DEVPL_ENV_KEY", "theKey", "MNO_DEVPL_ENV_SECRET", "theSecret");
 		MnoPropertiesHelper.setEnvironmentReader(new EnvironmentReader() {
 			@Override
 			public String getValue(String name) {
@@ -42,7 +42,7 @@ public class DevPlatformServiceTest {
 
 		DevPlatformService subject = new DevPlatformService(properties);
 		Assert.assertEquals("https://dev-platform.maestrano.com", subject.getHost());
-		Assert.assertEquals("/api/config/v1/marketplaces", subject.getV1Path());
+		Assert.assertEquals("/api/config/v1", subject.getApiPath());
 		Assert.assertEquals("theHost", subject.getEnvironmentName());
 		Assert.assertEquals("theKey", subject.getApiKey());
 		Assert.assertEquals("theSecret", subject.getApiSecret());
@@ -55,14 +55,14 @@ public class DevPlatformServiceTest {
 	public void constructor_itReturnTheRightValues() throws MnoConfigurationException {
 		Properties properties = new Properties();
 		properties.setProperty("dev-platform.host", "host");
-		properties.setProperty("dev-platform.v1Path", "v1Path");
+		properties.setProperty("dev-platform.apiPath", "apiPath");
 		properties.setProperty("environment.name", "name");
 		properties.setProperty("environment.apiKey", "apiKey");
 		properties.setProperty("environment.apiSecret", "apiSecret");
 
 		DevPlatformService subject = new DevPlatformService(properties);
 		Assert.assertEquals("host", subject.getHost());
-		Assert.assertEquals("v1Path", subject.getV1Path());
+		Assert.assertEquals("apiPath", subject.getApiPath());
 		Assert.assertEquals("name", subject.getEnvironmentName());
 		Assert.assertEquals("apiKey", subject.getApiKey());
 		Assert.assertEquals("apiSecret", subject.getApiSecret());
@@ -73,7 +73,7 @@ public class DevPlatformServiceTest {
 	public void constructor_throwsAnErrorWhenPropertiesAreMissing() throws MnoConfigurationException {
 		Properties properties = new Properties();
 		properties.setProperty("dev-platform.host", "host");
-		properties.setProperty("dev-platform.v1Path", "v1Path");
+		properties.setProperty("dev-platform.apiPath", "apiPath");
 		properties.setProperty("environment.name", "name");
 		properties.setProperty("environment.apiKey", "apiKey");
 		new DevPlatformService(properties);

--- a/src/test/java/com/maestrano/net/DevPlatformClientTest.java
+++ b/src/test/java/com/maestrano/net/DevPlatformClientTest.java
@@ -35,7 +35,7 @@ public class DevPlatformClientTest {
 
 	@Test
 	public void getInstanceUrl_ItReturnsTheRightInstanceUrl() {
-		assertEquals("https://dev-platform.maestrano.com/api/config/v1/marketplaces", subject.getInstanceUrl());
+		assertEquals("https://dev-platform.maestrano.com/api/config/v1", subject.getInstanceUrl());
 	}
 
 	@Test


### PR DESCRIPTION
## Environment Variables
- DEVPL_HOST -> MNO_DEVPL_HOST
- DEVPL_V1_PATH -> MNO_DEVPL_API_PATH
- ENVIRONMENT_NAME -> MNO_DEVPL_ENV_NAME
- ENVIRONMENT_KEY -> MNO_DEVPL_ENV_KEY
- ENVIRONMENT_SECRET -> MNO_DEVPL_ENV_SECRET
## Configuration property

v1Path -> apiPath and the "marketplaces" is not part of it anymore
